### PR TITLE
feat: mTLS Decoder

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function extractSocketDetails (socket, proto = {}) {
     proto.serverIpAddress = socket.address().address
     proto.ipFamily = getProtoIpFamily(socket.remoteFamily)
     proto.certAuthorized = socket.authorized;
-    proto.cert = getTlsClientCertificate(socket)
+    proto.cert = socket.getPeerCertificate(true)
   }
   return proto
 }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ function getProtoIpFamily (ipFamily) {
   return 0
 }
 
-
 function extractHttpDetails (req, socket, proto = {}) {
   const headers = req && req.headers ? req.headers : null
   if (headers) {
@@ -102,14 +101,14 @@ function extractSocketDetails (socket, proto = {}) {
     proto.port = socket._socket.remotePort
     proto.serverIpAddress = socket._socket.address().address
     proto.ipFamily = getProtoIpFamily(socket._socket.remoteFamily)
-    proto.certAuthorized = socket._socket.authorized;
+    proto.certAuthorized = socket._socket.authorized
     proto.cert = socket._socket.getPeerCertificate(true)
   } else if (socket.address) {
     proto.ipAddress = socket.remoteAddress
     proto.port = socket.remotePort
     proto.serverIpAddress = socket.address().address
     proto.ipFamily = getProtoIpFamily(socket.remoteFamily)
-    proto.certAuthorized = socket.authorized;
+    proto.certAuthorized = socket.authorized
     proto.cert = socket.getPeerCertificate(true)
   }
   return proto

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function extractSocketDetails (socket, proto = {}) {
     proto.serverIpAddress = socket._socket.address().address
     proto.ipFamily = getProtoIpFamily(socket._socket.remoteFamily)
     proto.certAuthorized = socket._socket.authorized;
-    proto.cert = getTlsClientCertificate(socket._socket)
+    proto.cert = socket._socket.getPeerCertificate(true)
   } else if (socket.address) {
     proto.ipAddress = socket.remoteAddress
     proto.port = socket.remotePort

--- a/index.js
+++ b/index.js
@@ -43,6 +43,16 @@ function getProtoIpFamily (ipFamily) {
   return 0
 }
 
+function getTlsClientCertificate (socket) {
+  /* Get mTLS Client Certificate */
+  const clientCert = socket.getPeerCertificate(true);
+  if(clientCert !== {} && clientCert !== null && clientCert !== undefined){
+    return clientCert;
+  } else {
+    return undefined; 
+  }
+}
+
 function extractHttpDetails (req, socket, proto = {}) {
   const headers = req && req.headers ? req.headers : null
   if (headers) {
@@ -101,11 +111,15 @@ function extractSocketDetails (socket, proto = {}) {
     proto.port = socket._socket.remotePort
     proto.serverIpAddress = socket._socket.address().address
     proto.ipFamily = getProtoIpFamily(socket._socket.remoteFamily)
+    proto.certAuthorized = socket._socket.authorized;
+    proto.cert = getTlsClientCertificate(socket._socket)
   } else if (socket.address) {
     proto.ipAddress = socket.remoteAddress
     proto.port = socket.remotePort
     proto.serverIpAddress = socket.address().address
     proto.ipFamily = getProtoIpFamily(socket.remoteFamily)
+    proto.certAuthorized = socket.authorized;
+    proto.cert = getTlsClientCertificate(socket)
   }
   return proto
 }

--- a/index.js
+++ b/index.js
@@ -43,15 +43,6 @@ function getProtoIpFamily (ipFamily) {
   return 0
 }
 
-function getTlsClientCertificate (socket) {
-  /* Get mTLS Client Certificate */
-  const clientCert = socket.getPeerCertificate(true);
-  if(clientCert !== {} && clientCert !== null && clientCert !== undefined){
-    return clientCert;
-  } else {
-    return undefined; 
-  }
-}
 
 function extractHttpDetails (req, socket, proto = {}) {
   const headers = req && req.headers ? req.headers : null

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,9 @@ export interface ConnectionDetails {
   ipAddress: string
   port: number
   ipFamily: number
-  serverIpAddress: string
+  serverIpAddress: string,
+  certAuthorized: boolean,
+  cert: any,  // getPeerCertificate can return an empty object or null
   isWebsocket: boolean
   isProxy: number
   data?: Buffer


### PR DESCRIPTION
- [x] Add Decoder Code
- [ ] Update Readme of aedes-server-factory

Added Mutual TLS Decoder. This will specifically extract your client's certificate from TCP socket and add it to `client.connDetails.cert`.

You can also use `client.connDetails.certAuthorized` to see if certificate presented by client is valid or not.


Example code published in https://github.com/moscajs/aedes-server-factory/issues/3#issuecomment-843973539
